### PR TITLE
WIP: Depend on our own abseil again

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -66,8 +66,7 @@ fi
 # see https://github.com/conda-forge/jaxlib-feedstock/issues/89
 #
 # Thus: don't add com_google_protobuf here.
-# FIXME: Current global abseil pin is too old for jaxlib, readd com_google_absl once we are on a newer version.
-export TF_SYSTEM_LIBS="boringssl,com_github_googlecloudplatform_google_cloud_cpp,com_github_grpc_grpc,flatbuffers,zlib"
+export TF_SYSTEM_LIBS="boringssl,com_google_absl,com_github_googlecloudplatform_google_cloud_cpp,com_github_grpc_grpc,flatbuffers,zlib"
 
 if [[ "${target_platform}" == "osx-arm64" || "${target_platform}" != "${build_platform}" ]]; then
     EXTRA="--target_cpu ${TARGET_CPU}"


### PR DESCRIPTION
Something I couldn't pull off in #192, perhaps someone can help.

The issue is that jaxlib calls another bazel build for the vendored xla, which then does not pick up the correct `@com_google_absl` anymore. That's despite xla having [logic](https://github.com/openxla/xla/blob/61e927c7de1d93683fa1f7da9e2ff0a656433817/configure.py#L808-L814) for processing `TF_SYSTEM_LIBS`, but it seems bazel isolation doesn't pass the variable down. I tried various things like
```diff
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -74,6 +74,7 @@ else
     EXTRA="${CUDA_ARGS:-}"
 fi
 ${PYTHON} build/build.py \
+    --bazel_options=--action_env=TF_SYSTEM_LIBS=${TF_SYSTEM_LIBS} \
     --target_cpu_features default \
     --enable_mkl_dnn \
     ${EXTRA}
```
and
```diff
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -74,6 +74,7 @@ else
     EXTRA="${CUDA_ARGS:-}"
 fi
 ${PYTHON} build/build.py \
+    --bazel_options=--override_repository=com_google_absl=$PREFIX/lib \
     --target_cpu_features default \
     --enable_mkl_dnn \
     ${EXTRA}
```
but to no success.