### PR TITLE
Change boringssl patch file to work with 0.4.24+

### DIFF
--- a/recipe/patches/0002-xla-Support-third-party-build-of-boringssl.patch
+++ b/recipe/patches/0002-xla-Support-third-party-build-of-boringssl.patch
@@ -77,9 +77,7 @@ index a6f972c..456a0a8 100644
          sha256 = XLA_SHA256,
          strip_prefix = "xla-{commit}".format(commit = XLA_COMMIT),
          urls = tf_mirror_urls("https://github.com/openxla/xla/archive/{commit}.tar.gz".format(commit = XLA_COMMIT)),
--        patch_file = ["//third_party/xla:log.patch"],
 +        patch_file = [
-+            "//third_party/xla:log.patch",
 +            "//third_party/xla:0001-Support-third-party-build-of-boringssl.patch",
 +        ],
      )


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I found why this isn't build for the newest versions, and I tested locally at least on OSX and found out why. It's because the patch file for the bazel workspace references a line that was removed in v0.4.24 [commit here](https://github.com/google/jax/commit/cf5a49584d613e0cc048a3f33650155442fb47ca), which caused the patch command to fail, at least on osx locally and in azure.
I'm not totally sure what the procedure is for something like this. Happy to reopen this PR against the version bump PR instead. Let me know what you need me to do. 
EDIT: especially let me know how to proceed given that it's failing CI. Thanks!

EDIT 2: I submitted a [PR](https://github.com/regro-cf-autotick-bot/jaxlib-feedstock/pull/1) against the bot branch as well. The maintenance instructions say to push to that branch but i dont have permission. Thanks!