### PR TITLE
Use build instead of number as variable for build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set version = "0.4.25" %}
-{% set number = 0 %}
+{% set build = 0 %}
 
 {% if cuda_compiler_version != "None" %}
-{% set number = number + 200 %}
+{% set build = build + 200 %}
 {% endif %}
 
 
@@ -20,7 +20,7 @@ source:
     - patches/0003-xla-Fix-abseil-headers.patch
 
 build:
-  number: {{ number }}
+  number: {{ build }}
   skip: true  # [win or py<39]
   skip: true  # [cuda_compiler != "None" and aarch64]
   skip: true  # [cuda_compiler_version == "11.2"]


### PR DESCRIPTION
I noticed that recent rebuild were not bumping the build number, see for example:
* https://github.com/conda-forge/jaxlib-feedstock/pull/244
* https://github.com/conda-forge/jaxlib-feedstock/pull/234
* https://github.com/conda-forge/jaxlib-feedstock/pull/231

I looked into this, and apparently the bot assumes that the variable used to set the build number needs to be called either `build` or `build_number`, but not `number` as done in this recipe, see https://github.com/regro/cf-scripts/blob/bc57282361ba7437a46ee7ddde0783b94f1c1bc8/conda_forge_tick/update_recipe/build_number.py#L5-L11 .

I choose to use `build` as it is the variable name more used in conda-forge and used in the knowledge base: https://github.com/conda-forge/conda-forge.github.io/blob/26db656d1b1828b14fa24f16820ba30ec31c387f/docs/maintainer/knowledge_base.md#L968 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
